### PR TITLE
Fix invalid add-on image name

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1
+
+Fix add-on image name format
+
 ## 4.0.0
 
 BREAKING CHANGE: Nginx is updated to version 1.20.2. As part of this update, we are switching from the default Alpine nginx package to the nginx.org package to streamline the process to install ModSecurity. The nginx.org package is only available for aarch64 and amd64. Therefore, the following CPU architectures are no longer supported:

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy with WAF",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "slug": "nginx_proxy_waf",
   "description": "An SSL/TLS proxy",
   "url": "https://github.com/jhampson-dbre/addon-nginx-proxy-waf",
@@ -52,5 +52,5 @@
       "debug": "bool?"
     }
   },
-  "image": "jhampdbre/{arch}-nginx-1.20.2-proxy-waf"
+  "image": "jhampdbre/{arch}-nginx-1-20-2-proxy-waf"
 }


### PR DESCRIPTION
Home Assistant doesn't like `.` in add-on image names. Replace `.` with `-` in image name to pass name validation.