### PR TITLE
Allow custom external exclusions file for modsecurity rules

### DIFF
--- a/nginx_proxy/CHANGELOG.md
+++ b/nginx_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.0
+
+Add new `security.customize` option to allow for creating custom ModSecurity exclusion rules. See the docs for details.
+
 ## 4.0.1
 
 Fix add-on image name format

--- a/nginx_proxy/DOCS.md
+++ b/nginx_proxy/DOCS.md
@@ -90,6 +90,21 @@ Controls the behavior of ModSecurity web application firewall. Allowed values ar
 
 If true, writes the ModSecurity audit log to the addon log. Useful for reporting false positives.
 
+### Option `security.customize` (optional)
+
+If true, loads custom ModSecurity rules files from /share/nginx_proxy/rules/*.conf
+
+**WARNING:** Do NOT enable this option without first creating a valid ModSecurity rules file in `/share/nginx_proxy/rules`. Rules files should be named using the ModSecurity standard naming convention, such as `REQUEST-900.9002-HOME-ASSISTANT-CUSTOM-EXCLUSION-RULES.conf`
+
+If this option is enabled without creating a valid rules file, the add-on will not be able to start.
+So that you can still access Home Assistant if the add-on is unable to start, you should access Home Assistant using the internal connection URL (e.g. homeassistant.local:8123) or IP address when enabling this option or making changes to custom rules files.
+
+Helpful resources for how to write ModSecurity exclusion rules:
+
+- [Handling False Positives in ModSecurity](https://www.netnea.com/cms/apache-tutorial-8_handling-false-positives-modsecurity-core-rule-set/)
+- [Example: OWASP Core Rule Set](https://github.com/coreruleset/coreruleset/tree/v3.3/master/rules)
+- [Example: Custom exlusions included with this add-on](https://github.com/jhampson-dbre/nginx-proxy-waf/blob/main/nginx_proxy/rootfs/usr/local/owasp-modsecurity-crs/rules/REQUEST-900.9001-HOME-ASSISTANT-EXCLUSION-RULES.conf)
+
 ## Known issues and limitations
 
 - By default, port 80 is disabled in the add-on configuration in case the port is needed for other components or add-ons like `emulated_hue`.

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -18,6 +18,7 @@
     "ssl",
     "share"
   ],
+  "stdin": true,
   "options": {
     "domain": null,
     "certfile": "fullchain.pem",
@@ -32,7 +33,8 @@
     "security": {
       "active": false,
       "mode": "DetectionOnly",
-      "debug": true
+      "debug": true,
+      "customize": false
     }
   },
   "schema": {
@@ -49,7 +51,8 @@
     "security": {
       "active": "bool",
       "mode": "list(DetectionOnly|On)",
-      "debug": "bool?"
+      "debug": "bool?",
+      "customize": "bool?"
     }
   },
   "image": "jhampdbre/{arch}-nginx-1-20-2-proxy-waf"

--- a/nginx_proxy/config.json
+++ b/nginx_proxy/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NGINX Home Assistant SSL proxy with WAF",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "slug": "nginx_proxy_waf",
   "description": "An SSL/TLS proxy",
   "url": "https://github.com/jhampson-dbre/addon-nginx-proxy-waf",

--- a/nginx_proxy/rootfs/etc/nginx/modsec/main.conf
+++ b/nginx_proxy/rootfs/etc/nginx/modsec/main.conf
@@ -1,3 +1,4 @@
 Include "/etc/nginx/modsec/modsecurity.conf"
 Include "/usr/local/owasp-modsecurity-crs/crs-setup.conf"
 Include "/usr/local/owasp-modsecurity-crs/rules/*.conf"
+#Include "/share/nginx_proxy/rules/*.conf"

--- a/nginx_proxy/rootfs/run.sh
+++ b/nginx_proxy/rootfs/run.sh
@@ -83,6 +83,11 @@ if bashio::config.true 'security.active'; then
     else
         sed -i "s|%%SECURITY_DEBUG%%|/var/log/modsec_audit.log|g" /etc/nginx/modsec/modsecurity.conf
     fi
+
+    if bashio::config.true 'security.customize'; then
+        sed -i 's|#Include "/share/nginx_proxy/rules/*.conf"|Include "/share/nginx_proxy/rules/*.conf"|' /etc/modsec/main.conf
+    fi
+
 fi
 
 # start server


### PR DESCRIPTION
Since Home Assistant support an nearly unlimited assortment of integration and add-ons, it would not be possible to write an all-inclusive exclusions file for every possible false positive to that could be encountered.

Furthermore, it can be very difficult to reproduce false positives across systems. For example, if a false positive is encountered while using the Alexa integration, this could only be reproduced on another system that has the Alexa integration configured, which involves creating an Amazon developer account, creating a custom Alexa skill, writing Lamba functions, etc.

With this changes, users can write and maintain their own custom exclusions rules, allowing a path to fix their own false positives without rquiring a new release of the add-on.

Fixes #6