### PR TITLE
Update modsecurity package

### DIFF
--- a/.github/workflows/ci_modsecurity.yml
+++ b/.github/workflows/ci_modsecurity.yml
@@ -4,11 +4,9 @@ name: CI modsecurity
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [main]
-    paths:
-      - "nginx_proxy/modsecurity/**"
+  # Triggers the workflow on pull request events but only for the main branch
+  # Don't run on merge to master because it takes a long time to run and usually
+  # we want to publish right after merging
   pull_request:
     branches: [main]
     paths:
@@ -31,7 +29,7 @@ jobs:
           args: |
             --test \
             --all \
-            --generic 1.0.1 \
+            --generic 2.0.0 \
             --target nginx_proxy/modsecurity/
 
   build_nginx:

--- a/.github/workflows/publish_modsecurity.yml
+++ b/.github/workflows/publish_modsecurity.yml
@@ -1,4 +1,4 @@
-name: Publish All
+name: Publish ModSecurity
 
 on:
   workflow_dispatch:
@@ -21,23 +21,4 @@ jobs:
             --all \
             --generic 2.0.0 \
             --target nginx_proxy/modsecurity/ \
-            --docker-hub jhampdbre
-  publish_nginx:
-    name: Publish nginx
-    needs: publish_modsecurity
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Publish nginx
-        uses: home-assistant/builder@master
-        with:
-          args: |
-            --all \
-            --target nginx_proxy/ \
             --docker-hub jhampdbre

--- a/nginx_proxy/modsecurity/build.json
+++ b/nginx_proxy/modsecurity/build.json
@@ -1,12 +1,12 @@
 {
-  "version": "1.0.1",
+  "version": "2.0.0",
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.14",
-    "amd64": "ghcr.io/home-assistant/amd64-base:3.14"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base:3.18",
+    "amd64": "ghcr.io/home-assistant/amd64-base:3.18"
   },
-  "image": "jhampdbre/{arch}-nginx-1.20.2-modsecurity",
+  "image": "jhampdbre/{arch}-nginx-1.24.0-modsecurity",
   "args": {
-    "NGINX_VERSION": "1.20.2",
+    "NGINX_VERSION": "1.24.0",
     "MODSEC_BRANCH": "v3/master",
     "OWASP_BRANCH": "v3.3/master"
   }


### PR DESCRIPTION
BREAKING CHANGE:

- Drop support for Alpine 3.14 and nginx 1.20.2
- Update modsecurity from v3/master
- Update CRS from v3.3/master (no changes since 11/2022)
- Support alpine 3.18
- Support nginx 1.24.0